### PR TITLE
Fix wait jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ local/
 !.travis.yml
 scratch.py
 *.env
+*.sqlite

--- a/adwords_client/client_operations.py
+++ b/adwords_client/client_operations.py
@@ -25,22 +25,18 @@ def adwords_worker(timestamp,
     config_file_path = kwargs.pop('config_file', None)
     adwords = AdWords.autoload(config_file_path)
     try:
+        drop_batchlog_table = kwargs.pop('drop_batchlog_table', False)
+        if drop_batchlog_table and total_procs > 1:
+            raise RuntimeError('Dropping tables is not allowed when running with multiprocessing...')
         mapper.set_lock(LOCK)
         if kwargs.pop('map_data', True):
             mapper.map_data(adwords, internal_table, proc_id, total_procs)
-        # remove operations log table argument before function call
-        operations_log_table = kwargs.pop('operations_log_table', None)
-        drop_batchlog_table = kwargs.pop('drop_batchlog_table', False)
-        drop_operations_log_table = kwargs.pop('drop_operations_log_table', False)
         # keep this argument since batch operations write to this table locally
         batchlog_table = kwargs.get('batchlog_table', None)
         operation_function(adwords, internal_table, *args, **kwargs)
         if batchlog_table:
             timestamp_client_table(adwords, batchlog_table, timestamp)
             mapper.upsync(adwords, batchlog_table, batchlog_table, drop_table=drop_batchlog_table)
-        if operations_log_table:
-            timestamp_client_table(adwords, internal_table, timestamp)
-            mapper.upsync(adwords, internal_table, operations_log_table, drop_table=drop_operations_log_table)
         mapper.set_lock(None)
     except Exception as e:
         logger.exception(e)

--- a/adwords_client/mappers/sqlite.py
+++ b/adwords_client/mappers/sqlite.py
@@ -1,0 +1,54 @@
+import logging
+import pandas as pd
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+
+logger = logging.getLogger(__name__)
+
+
+class SqliteMapper:
+    def __init__(self, table_mappings, connection_factory):
+        self.table_mappings = table_mappings
+        self.engine = None
+        self.connection_factory = connection_factory
+        self.lock = None
+
+    def set_lock(self, lock):
+        self.lock = lock
+
+    def get_engine(self):
+        if not self.engine:
+            self.engine = self.connection_factory()
+        return self.engine
+
+    def map_data(self, client, table_name, group_id, n_groups):
+        full_table_name = table_name
+
+        # build query, only split data if campaign_id exists
+        if self.table_mappings and 'campaign_id' in self.table_mappings:
+            query_fields = ','.join(field for field in self.table_mappings.values())
+            query = text('select {} from {} where abs({}) % {} = {}'.format(
+                query_fields, full_table_name, self.table_mappings['campaign_id'], n_groups, group_id)
+            )
+        else:
+            if n_groups > 1:
+                logger.warning('"campaing_id" field not in table, can not automatically split data, '
+                               'reading full data in all workers')
+            query = 'select * from {}'.format(full_table_name)
+
+        df = pd.read_sql(query, self.get_engine())
+        client.dump_table(df, table_name, table_mappings=self.table_mappings)
+
+    def upsync(self, client, source_table, target_table, drop_table=False):
+        try:
+            df = client.load_table(source_table)
+        except OperationalError:
+            return
+        if not df.empty:
+            with self.lock:
+                df.to_sql(target_table, self.engine, index=False, if_exists='replace' if drop_table else 'append')
+
+    def drop_table(self, table_name):
+        logger.info('Dropping table...')
+        with self.lock, self.get_engine().begin() as conn:
+            conn.execute('DROP TABLE IF EXISTS {}'.format(table_name))

--- a/adwords_client/sqlite.py
+++ b/adwords_client/sqlite.py
@@ -88,27 +88,6 @@ def remove_temporary_files():
             pass
 
 
-def dict_query(conn, query, n_key=1, *args):
-    data = conn.execute(query).fetchall()
-    result = {}
-    args = [n_key] + list(args)
-    for row in data:
-        key_pos = 0
-        curr_dict = result
-        for n_key in args[:-1]:
-            key = tuple(row[key_pos:key_pos + n_key]) if n_key > 1 else row[key_pos]
-            if key not in curr_dict:
-                curr_dict[key] = {}
-            key_pos += n_key
-            curr_dict = curr_dict[key]
-        n_key = args[-1]
-        key = tuple(row[key_pos:key_pos + n_key]) if n_key > 1 else row[key_pos]
-        if key not in curr_dict:
-            curr_dict[key] = []
-        curr_dict[key].append(row)
-    return result
-
-
 def create_index(engine, table_name, *args):
     idx_name = '_'.join(args)
     idx_fields = ', '.join(args)

--- a/adwords_client/sqlite.py
+++ b/adwords_client/sqlite.py
@@ -13,7 +13,10 @@ TEMPORARY_FILES = []
 
 
 def itertable(engine, table_name):
-    model = get_model_from_table(table_name, engine)
+    try:
+        model = get_model_from_table(table_name, engine)
+    except AttributeError:
+        return
     Session = sqlalchemy.orm.sessionmaker(bind=engine)
     s = Session()
     for instance in s.query(model).order_by(model.id):

--- a/adwords_client/utils.py
+++ b/adwords_client/utils.py
@@ -1,7 +1,5 @@
 import re
 import math
-import typing
-from pandas import isnull
 
 double_regex = re.compile(r'[^\d.]+')
 
@@ -51,14 +49,21 @@ class AdwordsMapper:
         self.adapter = adapter
 
     def to_adwords(self, value):
-        return self.adapter(value)
+        if value and (type(value) != float or (type(value) == float and not math.isnan(value))):
+            return self.adapter(value)
+        else:
+            return None
 
     def from_adwords(self, value):
-        return self.converter(value)
+        if value and (type(value) != float or (type(value) == float and not math.isnan(value))):
+            return self.converter(value)
+        else:
+            return None
 
     @property
     def from_adwords_func(self):
         return self.converter
+
 
 MAPPERS = {
     'Money': AdwordsMapper(raw_money_as_cents, cents_as_money),


### PR DESCRIPTION
The new internal representation with a serialized json had a conflict with our batch log table. Solving this performing a transformation before uploading to the external source. Also, since we can no longer perform simple sql queries in the internal database, we save the "min" value for each inserted operation of each table in order to generate new negative ids in case it is needed when executing batch jobs.